### PR TITLE
Refine pipeline options UI with millimetre preview

### DIFF
--- a/client/app/routes/home/components/CropPreview.tsx
+++ b/client/app/routes/home/components/CropPreview.tsx
@@ -8,9 +8,23 @@ export type CropPreviewProps = {
   widthHeightRatio: number;
   topMarginRatio: number;
   lowerFaceRatio: number;
+  heading: string;
+  description: string;
+  aspectLabel: string;
+  topMarginLabel: string;
+  bottomPaddingLabel: string;
 };
 
-export function CropPreview({ widthHeightRatio, topMarginRatio, lowerFaceRatio }: CropPreviewProps) {
+export function CropPreview({
+  widthHeightRatio,
+  topMarginRatio,
+  lowerFaceRatio,
+  heading,
+  description,
+  aspectLabel,
+  topMarginLabel,
+  bottomPaddingLabel,
+}: CropPreviewProps) {
   const geometry = useMemo(
     () => computeGeometry(widthHeightRatio, topMarginRatio, lowerFaceRatio),
     [lowerFaceRatio, topMarginRatio, widthHeightRatio],
@@ -18,10 +32,8 @@ export function CropPreview({ widthHeightRatio, topMarginRatio, lowerFaceRatio }
 
   return (
     <div className="flex flex-col gap-3 rounded-xl border border-slate-200 bg-white/80 p-4 shadow-inner dark:border-slate-700 dark:bg-slate-900/60">
-      <div className="text-sm font-semibold text-slate-700 dark:text-slate-200">Live framing preview</div>
-      <div className="text-xs text-slate-500 dark:text-slate-400">
-        Adjust the controls to see how the top margin, lower face ratio, and width/height ratio change the crop box and face placement.
-      </div>
+      <div className="text-sm font-semibold text-slate-700 dark:text-slate-200">{heading}</div>
+      <div className="text-xs text-slate-500 dark:text-slate-400">{description}</div>
       <div className="relative mx-auto w-full max-w-[180px] rounded-lg border border-slate-300 bg-white dark:border-slate-700 dark:bg-slate-900/70">
         <div
           className="relative w-full"
@@ -47,9 +59,9 @@ export function CropPreview({ widthHeightRatio, topMarginRatio, lowerFaceRatio }
         </div>
       </div>
       <div className="grid gap-2 text-xs text-slate-600 dark:text-slate-400 sm:grid-cols-3">
-        <Stat label="Aspect" value={`${geometry.safeRatio.toFixed(2)} : 1`} />
-        <Stat label="Top margin" value={`${(geometry.topMarginPercent).toFixed(0)}%`} />
-        <Stat label="Lower padding" value={`${geometry.bottomMarginPercent.toFixed(0)}%`} />
+        <Stat label={aspectLabel} value={`${geometry.safeRatio.toFixed(2)} : 1`} />
+        <Stat label={topMarginLabel} value={`${geometry.topMarginPercent.toFixed(0)}%`} />
+        <Stat label={bottomPaddingLabel} value={`${geometry.bottomMarginPercent.toFixed(0)}%`} />
       </div>
     </div>
   );

--- a/client/app/routes/home/components/MmBudgetPreview.tsx
+++ b/client/app/routes/home/components/MmBudgetPreview.tsx
@@ -1,0 +1,209 @@
+import classNames from "classnames";
+import { useMemo } from "react";
+
+type MmBudgetPreviewProps = {
+  targetHeightMm: number;
+  minTopMm: number;
+  minBottomMm: number;
+  shoulderClearanceMm: number;
+  minCrownToChinMm: number;
+  maxCrownToChinMm: number;
+  targetCrownToChinMm: number;
+  unitLabel: string;
+  heading: string;
+  description: string;
+  topLabel: string;
+  faceLabel: string;
+  bottomLabel: string;
+  shoulderHint: string;
+  totalLabel: string;
+};
+
+const EPSILON = 1e-3;
+
+type MmBudgetGeometry = {
+  topMm: number;
+  faceMm: number;
+  bottomMm: number;
+  totalMm: number;
+  topPercent: number;
+  facePercent: number;
+  bottomPercent: number;
+  topLimited: boolean;
+  bottomLimited: boolean;
+  faceLimited: boolean;
+};
+
+export function MmBudgetPreview(props: MmBudgetPreviewProps) {
+  const geometry = useMemo(() => computeBudgetGeometry(props), [props]);
+
+  return (
+    <div className="flex flex-col gap-3 rounded-xl border border-slate-200 bg-white/80 p-4 shadow-inner dark:border-slate-700 dark:bg-slate-900/60">
+      <div className="text-sm font-semibold text-slate-700 dark:text-slate-200">{props.heading}</div>
+      <div className="text-xs text-slate-500 dark:text-slate-400">{props.description}</div>
+      <div className="mx-auto flex w-full max-w-[220px] flex-col items-center gap-4 sm:flex-row sm:items-start">
+        <div className="relative flex h-48 w-24 flex-col overflow-hidden rounded-md border border-slate-300 dark:border-slate-700">
+          <BudgetSegment
+            percent={geometry.topPercent}
+            label={props.topLabel}
+            value={formatMm(geometry.topMm, props.unitLabel)}
+            tone="top"
+            limited={geometry.topLimited}
+          />
+          <BudgetSegment
+            percent={geometry.facePercent}
+            label={props.faceLabel}
+            value={formatMm(geometry.faceMm, props.unitLabel)}
+            tone="face"
+            limited={geometry.faceLimited}
+          />
+          <BudgetSegment
+            percent={geometry.bottomPercent}
+            label={props.bottomLabel}
+            value={formatMm(geometry.bottomMm, props.unitLabel)}
+            tone="bottom"
+            limited={geometry.bottomLimited}
+          />
+        </div>
+        <div className="flex flex-1 flex-col gap-2 text-xs text-slate-600 dark:text-slate-400">
+          <PreviewStat
+            label={props.topLabel}
+            value={formatMm(geometry.topMm, props.unitLabel)}
+            limited={geometry.topLimited}
+          />
+          <PreviewStat
+            label={props.faceLabel}
+            value={formatMm(geometry.faceMm, props.unitLabel)}
+            limited={geometry.faceLimited}
+          />
+          <PreviewStat
+            label={props.bottomLabel}
+            value={formatMm(geometry.bottomMm, props.unitLabel)}
+            limited={geometry.bottomLimited}
+          />
+          <PreviewStat
+            label={props.totalLabel}
+            value={formatMm(geometry.totalMm, props.unitLabel)}
+          />
+          <div className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-[0.7rem] font-medium text-amber-700 shadow-sm dark:border-amber-800 dark:bg-amber-950/50 dark:text-amber-200">
+            {props.shoulderHint.replace("{clearance}", formatMm(props.shoulderClearanceMm, props.unitLabel))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+type BudgetSegmentProps = {
+  percent: number;
+  label: string;
+  value: string;
+  tone: "top" | "face" | "bottom";
+  limited?: boolean;
+};
+
+function BudgetSegment({ percent, label, value, tone, limited }: BudgetSegmentProps) {
+  return (
+    <div
+      className={classNames(
+        "flex flex-col items-center justify-center gap-1 border-b border-slate-200 px-2 text-center text-[0.7rem] font-semibold uppercase tracking-wide dark:border-slate-700",
+        tone === "top" && "bg-sky-50 text-sky-700 dark:bg-sky-950/40 dark:text-sky-200",
+        tone === "face" && "bg-emerald-50 text-emerald-700 dark:bg-emerald-950/40 dark:text-emerald-200",
+        tone === "bottom" && "bg-indigo-50 text-indigo-700 dark:bg-indigo-950/40 dark:text-indigo-200",
+        limited && "outline outline-2 outline-dashed outline-amber-400/70",
+      )}
+      style={{ flexGrow: Math.max(percent, 0.1), flexBasis: 0, minHeight: "2.75rem" }}
+    >
+      <span>{label}</span>
+      <span className="text-[0.65rem] font-normal normal-case text-slate-600 dark:text-slate-300">{value}</span>
+      {limited && (
+        <span className="text-[0.6rem] font-semibold uppercase text-amber-600 dark:text-amber-300">Min</span>
+      )}
+    </div>
+  );
+}
+
+type PreviewStatProps = {
+  label: string;
+  value: string;
+  limited?: boolean;
+};
+
+function PreviewStat({ label, value, limited }: PreviewStatProps) {
+  return (
+    <div
+      className={classNames(
+        "flex items-center justify-between gap-3 rounded-md border border-slate-200 bg-white/70 px-3 py-2 text-[0.75rem] font-medium text-slate-600 shadow-sm dark:border-slate-700 dark:bg-slate-900/50 dark:text-slate-300",
+        limited && "border-amber-300 text-amber-700 dark:border-amber-700 dark:text-amber-200",
+      )}
+    >
+      <span>{label}</span>
+      <span className="text-sm font-semibold text-slate-800 dark:text-slate-100">{value}</span>
+    </div>
+  );
+}
+
+function formatMm(value: number, unitLabel: string) {
+  return `${value.toFixed(1)} ${unitLabel}`;
+}
+
+function computeBudgetGeometry({
+  targetHeightMm,
+  minTopMm,
+  minBottomMm,
+  minCrownToChinMm,
+  maxCrownToChinMm,
+  targetCrownToChinMm,
+}: MmBudgetPreviewProps): MmBudgetGeometry {
+  const safeTargetHeight = Math.max(targetHeightMm, 1);
+  const minTop = Math.max(0, minTopMm);
+  const minBottom = Math.max(0, minBottomMm);
+  const crownMin = Math.max(1, minCrownToChinMm);
+  const crownMax = Math.max(crownMin, maxCrownToChinMm);
+
+  let faceMm = clamp(targetCrownToChinMm, crownMin, crownMax);
+
+  const reduceFace = () => {
+    const candidate = clamp(safeTargetHeight - minTop - minBottom, crownMin, faceMm);
+    faceMm = candidate;
+  };
+
+  let topMm = safeTargetHeight - faceMm - minBottom;
+  if (topMm < minTop - EPSILON) {
+    reduceFace();
+    topMm = safeTargetHeight - faceMm - minBottom;
+  }
+
+  if (topMm < minTop) {
+    topMm = Math.max(0, minTop);
+  }
+
+  let bottomMm = safeTargetHeight - faceMm - topMm;
+  if (bottomMm < minBottom) {
+    bottomMm = minBottom;
+    const remaining = safeTargetHeight - bottomMm;
+    faceMm = clamp(Math.max(remaining - topMm, crownMin), crownMin, faceMm);
+    topMm = Math.max(minTop, remaining - faceMm);
+  }
+
+  const totalMm = topMm + faceMm + bottomMm;
+  const normaliser = totalMm > 0 ? totalMm : 1;
+
+  return {
+    topMm,
+    faceMm,
+    bottomMm,
+    totalMm,
+    topPercent: (topMm / normaliser) * 100,
+    facePercent: (faceMm / normaliser) * 100,
+    bottomPercent: (bottomMm / normaliser) * 100,
+    topLimited: topMm <= minTop + 0.05,
+    bottomLimited: bottomMm <= minBottom + 0.05,
+    faceLimited: Math.abs(faceMm - crownMin) <= 0.05 || Math.abs(faceMm - crownMax) <= 0.05,
+  };
+}
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(Math.max(value, min), max);
+}
+

--- a/client/app/routes/home/components/OptionsSection.tsx
+++ b/client/app/routes/home/components/OptionsSection.tsx
@@ -1,9 +1,10 @@
 import type { ChangeEvent } from "react";
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import classNames from "classnames";
 
 import type { OptionsSectionProps } from "../types";
 import { CropPreview } from "./CropPreview";
+import { MmBudgetPreview } from "./MmBudgetPreview";
 
 export function OptionsSection({
   messages,
@@ -15,8 +16,6 @@ export function OptionsSection({
   canSubmit,
   onRetry,
 }: OptionsSectionProps) {
-  const [showAdvanced, setShowAdvanced] = useState(false);
-
   const disabled = status === "processing";
   const isClosedForm = formValues.pipeline === "closed_form";
 
@@ -39,6 +38,14 @@ export function OptionsSection({
           step={0.1}
           disabled={disabled}
         />
+        <RatioInput
+          label={messages.targetRatioLabel}
+          value={formValues.target_w_over_h}
+          onChange={(value) => onOptionChange("target_w_over_h", value)}
+          min={0.5}
+          max={1.5}
+          disabled={disabled}
+        />
         <NumberInput
           label={messages.minHeightLabel}
           suffix={messages.pixelsSuffix}
@@ -57,7 +64,57 @@ export function OptionsSection({
           step={2}
           disabled={disabled}
         />
-        <label className="flex items-start gap-3 rounded-lg border border-slate-200 bg-slate-50 p-3 text-sm text-slate-700 shadow-inner dark:border-slate-700 dark:bg-slate-800 dark:text-slate-200">
+        <div className="sm:col-span-2">
+          <PercentageSlider
+            label={messages.resizeScalingLabel}
+            value={formValues.resize_scaling}
+            onChange={(value) => onOptionChange("resize_scaling", value)}
+            minPercent={0}
+            maxPercent={100}
+            disabled={disabled}
+          />
+        </div>
+        <NumberInput
+          label={messages.maxCrownToChinLabel}
+          suffix={messages.measurementUnitMm}
+          value={formValues.max_crown_to_chin_mm}
+          onChange={(value) => onOptionChange("max_crown_to_chin_mm", value)}
+          step={0.5}
+          min={10}
+          max={60}
+          disabled={disabled}
+        />
+        <NumberInput
+          label={messages.minCrownToChinLabel}
+          suffix={messages.measurementUnitMm}
+          value={formValues.min_crown_to_chin_mm}
+          onChange={(value) => onOptionChange("min_crown_to_chin_mm", value)}
+          step={0.5}
+          min={10}
+          max={60}
+          disabled={disabled}
+        />
+        <NumberInput
+          label={messages.targetCrownToChinLabel}
+          suffix={messages.measurementUnitMm}
+          value={formValues.target_crown_to_chin_mm}
+          onChange={(value) => onOptionChange("target_crown_to_chin_mm", value)}
+          step={0.5}
+          min={10}
+          max={60}
+          disabled={disabled}
+        />
+        <NumberInput
+          label={messages.maxExtraPaddingLabel}
+          suffix={messages.pixelsSuffix}
+          value={formValues.max_extra_padding_px}
+          onChange={(value) => onOptionChange("max_extra_padding_px", value)}
+          step={10}
+          min={0}
+          max={2000}
+          disabled={disabled}
+        />
+        <label className="sm:col-span-2 flex items-start gap-3 rounded-lg border border-slate-200 bg-slate-50 p-3 text-sm text-slate-700 shadow-inner dark:border-slate-700 dark:bg-slate-800 dark:text-slate-200">
           <input
             type="checkbox"
             checked={formValues.save_debug}
@@ -96,139 +153,87 @@ export function OptionsSection({
           />
         </div>
       </fieldset>
-
-      <div className="mt-4 rounded-xl border border-slate-200 bg-slate-50 p-4 dark:border-slate-700 dark:bg-slate-800">
-        <button
-          type="button"
-          onClick={() => setShowAdvanced((current) => !current)}
-          className="flex w-full items-center justify-between gap-2 text-sm font-semibold text-slate-700 transition hover:text-slate-900 focus:outline-none focus:ring-2 focus:ring-sky-400 dark:text-slate-200 dark:hover:text-white"
-          aria-expanded={showAdvanced}
-          aria-controls="advanced-options"
-          aria-label={messages.ariaAdvancedToggle}
-        >
-          <span>{messages.advancedHeading}</span>
-          <span className="text-xs font-normal text-slate-500 dark:text-slate-400">
-            {messages.advancedSummary}
-          </span>
-        </button>
-        {showAdvanced && (
-          <div id="advanced-options" className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2">
-            <RatioInput
-              label={messages.targetRatioLabel}
-              value={formValues.target_w_over_h}
-              onChange={(value) => onOptionChange("target_w_over_h", value)}
-              min={0.5}
-              max={1.5}
-              disabled={disabled}
-            />
-            <PercentageSlider
-              label={messages.resizeScalingLabel}
-              value={formValues.resize_scaling}
-              onChange={(value) => onOptionChange("resize_scaling", value)}
-              minPercent={0}
-              maxPercent={100}
-              disabled={disabled}
-            />
-            {isClosedForm ? (
-              <>
-                <NumberInput
-                  label={messages.minTopMmLabel}
-                  suffix={messages.measurementUnitMm}
-                  value={formValues.min_top_mm}
-                  onChange={(value) => onOptionChange("min_top_mm", value)}
-                  step={0.5}
-                  min={0}
-                  disabled={disabled}
-                />
-                <NumberInput
-                  label={messages.minBottomMmLabel}
-                  suffix={messages.measurementUnitMm}
-                  value={formValues.min_bottom_mm}
-                  onChange={(value) => onOptionChange("min_bottom_mm", value)}
-                  step={0.5}
-                  min={0}
-                  disabled={disabled}
-                />
-                <NumberInput
-                  label={messages.shoulderClearanceLabel}
-                  suffix={messages.measurementUnitMm}
-                  value={formValues.shoulder_clearance_mm}
-                  onChange={(value) => onOptionChange("shoulder_clearance_mm", value)}
-                  step={0.5}
-                  min={0}
-                  disabled={disabled}
-                />
-              </>
-            ) : (
-              <>
-                <PercentageSlider
-                  label={messages.topMarginLabel}
-                  value={formValues.top_margin_ratio}
-                  onChange={(value) => onOptionChange("top_margin_ratio", value)}
-                  minPercent={0}
-                  maxPercent={50}
-                  disabled={disabled}
-                />
-                <PercentageSlider
-                  label={messages.bottomUpperLabel}
-                  value={formValues.bottom_upper_ratio}
-                  onChange={(value) => onOptionChange("bottom_upper_ratio", value)}
-                  minPercent={50}
-                  maxPercent={100}
-                  disabled={disabled}
-                />
-                <div className="sm:col-span-2">
-                  <CropPreview
-                    widthHeightRatio={formValues.target_w_over_h}
-                    topMarginRatio={formValues.top_margin_ratio}
-                    lowerFaceRatio={formValues.bottom_upper_ratio}
-                  />
-                </div>
-              </>
-            )}
-            <NumberInput
-              label={messages.maxCrownToChinLabel}
-              suffix={messages.measurementUnitMm}
-              value={formValues.max_crown_to_chin_mm}
-              onChange={(value) => onOptionChange("max_crown_to_chin_mm", value)}
-              step={0.5}
-              min={10}
-              max={60}
-              disabled={disabled}
-            />
-            <NumberInput
-              label={messages.minCrownToChinLabel}
-              suffix={messages.measurementUnitMm}
-              value={formValues.min_crown_to_chin_mm}
-              onChange={(value) => onOptionChange("min_crown_to_chin_mm", value)}
-              step={0.5}
-              min={10}
-              max={60}
-              disabled={disabled}
-            />
-            <NumberInput
-              label={messages.targetCrownToChinLabel}
-              suffix={messages.measurementUnitMm}
-              value={formValues.target_crown_to_chin_mm}
-              onChange={(value) => onOptionChange("target_crown_to_chin_mm", value)}
-              step={0.5}
-              min={10}
-              max={60}
-              disabled={disabled}
-            />
-            <NumberInput
-              label={messages.maxExtraPaddingLabel}
-              suffix={messages.pixelsSuffix}
-              value={formValues.max_extra_padding_px}
-              onChange={(value) => onOptionChange("max_extra_padding_px", value)}
-              step={10}
-              min={0}
-              max={2000}
-              disabled={disabled}
+      {isClosedForm ? (
+        <div className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2">
+          <NumberInput
+            label={messages.minTopMmLabel}
+            suffix={messages.measurementUnitMm}
+            value={formValues.min_top_mm}
+            onChange={(value) => onOptionChange("min_top_mm", value)}
+            step={0.5}
+            min={0}
+            disabled={disabled}
+          />
+          <NumberInput
+            label={messages.minBottomMmLabel}
+            suffix={messages.measurementUnitMm}
+            value={formValues.min_bottom_mm}
+            onChange={(value) => onOptionChange("min_bottom_mm", value)}
+            step={0.5}
+            min={0}
+            disabled={disabled}
+          />
+          <NumberInput
+            label={messages.shoulderClearanceLabel}
+            suffix={messages.measurementUnitMm}
+            value={formValues.shoulder_clearance_mm}
+            onChange={(value) => onOptionChange("shoulder_clearance_mm", value)}
+            step={0.5}
+            min={0}
+            disabled={disabled}
+          />
+          <div className="sm:col-span-2">
+            <MmBudgetPreview
+              targetHeightMm={formValues.target_height_mm}
+              minTopMm={formValues.min_top_mm}
+              minBottomMm={formValues.min_bottom_mm}
+              shoulderClearanceMm={formValues.shoulder_clearance_mm}
+              minCrownToChinMm={formValues.min_crown_to_chin_mm}
+              maxCrownToChinMm={formValues.max_crown_to_chin_mm}
+              targetCrownToChinMm={formValues.target_crown_to_chin_mm}
+              unitLabel={messages.measurementUnitMm}
+              heading={messages.closedFormPreviewHeading}
+              description={messages.closedFormPreviewDescription}
+              topLabel={messages.closedFormPreviewTopLabel}
+              faceLabel={messages.closedFormPreviewFaceLabel}
+              bottomLabel={messages.closedFormPreviewBottomLabel}
+              totalLabel={messages.closedFormPreviewTotalLabel}
+              shoulderHint={messages.closedFormPreviewShoulderHint}
             />
           </div>
-        )}
-      </div>
+        </div>
+      ) : (
+        <div className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2">
+          <PercentageSlider
+            label={messages.topMarginLabel}
+            value={formValues.top_margin_ratio}
+            onChange={(value) => onOptionChange("top_margin_ratio", value)}
+            minPercent={0}
+            maxPercent={50}
+            disabled={disabled}
+          />
+          <PercentageSlider
+            label={messages.bottomUpperLabel}
+            value={formValues.bottom_upper_ratio}
+            onChange={(value) => onOptionChange("bottom_upper_ratio", value)}
+            minPercent={50}
+            maxPercent={100}
+            disabled={disabled}
+          />
+          <div className="sm:col-span-2">
+            <CropPreview
+              widthHeightRatio={formValues.target_w_over_h}
+              topMarginRatio={formValues.top_margin_ratio}
+              lowerFaceRatio={formValues.bottom_upper_ratio}
+              heading={messages.legacyPreviewHeading}
+              description={messages.legacyPreviewDescription}
+              aspectLabel={messages.legacyPreviewAspectLabel}
+              topMarginLabel={messages.legacyPreviewTopLabel}
+              bottomPaddingLabel={messages.legacyPreviewBottomLabel}
+            />
+          </div>
+        </div>
+      )}
 
       <div className="mt-5 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <div className="text-xs text-slate-500 dark:text-slate-400">{messages.processingTimeHint}</div>

--- a/client/app/routes/home/messages.ts
+++ b/client/app/routes/home/messages.ts
@@ -143,6 +143,21 @@ export const MESSAGES: Record<Language, Messages> = {
     overlayHeading: "Interactive measurement preview",
     overlayLegendHeading: "Legend",
     resizeScalingLabel: "Preserve quality",
+    legacyPreviewHeading: "Legacy framing preview",
+    legacyPreviewDescription:
+      "Visualise how ratio-based margins place the face within the crop box.",
+    legacyPreviewAspectLabel: "Aspect",
+    legacyPreviewTopLabel: "Top margin",
+    legacyPreviewBottomLabel: "Lower padding",
+    closedFormPreviewHeading: "Closed-form mm budget",
+    closedFormPreviewDescription:
+      "See how millimetre limits are allocated between top margin, face span, and bottom margin.",
+    closedFormPreviewTopLabel: "Top allowance",
+    closedFormPreviewFaceLabel: "Face span",
+    closedFormPreviewBottomLabel: "Bottom allowance",
+    closedFormPreviewTotalLabel: "Total height",
+    closedFormPreviewShoulderHint:
+      "Shoulders require at least {clearance} of clearance below the chin when detected.",
   },
   it: {
     appTitle: "Assistente foto digitale",
@@ -285,6 +300,21 @@ export const MESSAGES: Record<Language, Messages> = {
     overlayHeading: "Anteprima interattiva delle misure",
     overlayLegendHeading: "Legenda",
     resizeScalingLabel: "Mantieni qualità",
+    legacyPreviewHeading: "Anteprima in modalità legacy",
+    legacyPreviewDescription:
+      "Visualizza come i margini basati sui rapporti posizionano il volto nel ritaglio.",
+    legacyPreviewAspectLabel: "Proporzione",
+    legacyPreviewTopLabel: "Margine superiore",
+    legacyPreviewBottomLabel: "Padding inferiore",
+    closedFormPreviewHeading: "Budget in mm (formule chiuse)",
+    closedFormPreviewDescription:
+      "Mostra come i limiti in millimetri vengono distribuiti tra margine superiore, volto e margine inferiore.",
+    closedFormPreviewTopLabel: "Margine superiore",
+    closedFormPreviewFaceLabel: "Altezza volto",
+    closedFormPreviewBottomLabel: "Margine inferiore",
+    closedFormPreviewTotalLabel: "Altezza totale",
+    closedFormPreviewShoulderHint:
+      "Le spalle richiedono almeno {clearance} di spazio sotto il mento quando rilevate.",
   },
   es: {
     appTitle: "Asistente de fotos digital",
@@ -427,5 +457,20 @@ export const MESSAGES: Record<Language, Messages> = {
     overlayHeading: "Vista interactiva de medidas",
     overlayLegendHeading: "Leyenda",
     resizeScalingLabel: "Mantener calidad",
+    legacyPreviewHeading: "Vista previa modo legacy",
+    legacyPreviewDescription:
+      "Visualiza cómo los márgenes basados en proporciones colocan el rostro dentro del recorte.",
+    legacyPreviewAspectLabel: "Proporción",
+    legacyPreviewTopLabel: "Margen superior",
+    legacyPreviewBottomLabel: "Acolchado inferior",
+    closedFormPreviewHeading: "Presupuesto en mm (forma cerrada)",
+    closedFormPreviewDescription:
+      "Muestra cómo se reparten los límites en milímetros entre margen superior, rostro y margen inferior.",
+    closedFormPreviewTopLabel: "Margen superior",
+    closedFormPreviewFaceLabel: "Altura del rostro",
+    closedFormPreviewBottomLabel: "Margen inferior",
+    closedFormPreviewTotalLabel: "Altura total",
+    closedFormPreviewShoulderHint:
+      "Los hombros necesitan al menos {clearance} de espacio bajo el mentón cuando se detectan.",
   },
 };

--- a/client/app/routes/home/types.ts
+++ b/client/app/routes/home/types.ts
@@ -180,6 +180,18 @@ export type Messages = {
   overlayHeading: string;
   overlayLegendHeading: string;
   resizeScalingLabel: string;
+  legacyPreviewHeading: string;
+  legacyPreviewDescription: string;
+  legacyPreviewAspectLabel: string;
+  legacyPreviewTopLabel: string;
+  legacyPreviewBottomLabel: string;
+  closedFormPreviewHeading: string;
+  closedFormPreviewDescription: string;
+  closedFormPreviewTopLabel: string;
+  closedFormPreviewFaceLabel: string;
+  closedFormPreviewBottomLabel: string;
+  closedFormPreviewTotalLabel: string;
+  closedFormPreviewShoulderHint: string;
 };
 
 export type FormValuesState = {


### PR DESCRIPTION
## Summary
- surface all framing controls at the primary level and adjust pipeline-specific layouts
- add a closed-form millimetre budget preview alongside localized copy for both pipelines

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dcf81798ec832d9a76a77befc4d976