### PR TITLE
Refine top margin handling and client warnings

### DIFF
--- a/client/app/routes/home.tsx
+++ b/client/app/routes/home.tsx
@@ -79,7 +79,6 @@ export default function Home() {
     max_extra_padding_px: 600,
     resize_scaling: 0,
     min_top_mm: 4,
-    min_bottom_mm: 8,
     shoulder_clearance_mm: 3,
   });
 

--- a/client/app/routes/home/components/OptionsSection.tsx
+++ b/client/app/routes/home/components/OptionsSection.tsx
@@ -165,15 +165,6 @@ export function OptionsSection({
             disabled={disabled}
           />
           <NumberInput
-            label={messages.minBottomMmLabel}
-            suffix={messages.measurementUnitMm}
-            value={formValues.min_bottom_mm}
-            onChange={(value) => onOptionChange("min_bottom_mm", value)}
-            step={0.5}
-            min={0}
-            disabled={disabled}
-          />
-          <NumberInput
             label={messages.shoulderClearanceLabel}
             suffix={messages.measurementUnitMm}
             value={formValues.shoulder_clearance_mm}
@@ -186,7 +177,6 @@ export function OptionsSection({
             <MmBudgetPreview
               targetHeightMm={formValues.target_height_mm}
               minTopMm={formValues.min_top_mm}
-              minBottomMm={formValues.min_bottom_mm}
               shoulderClearanceMm={formValues.shoulder_clearance_mm}
               minCrownToChinMm={formValues.min_crown_to_chin_mm}
               maxCrownToChinMm={formValues.max_crown_to_chin_mm}

--- a/client/app/routes/home/messages.ts
+++ b/client/app/routes/home/messages.ts
@@ -158,6 +158,12 @@ export const MESSAGES: Record<Language, Messages> = {
     closedFormPreviewTotalLabel: "Total height",
     closedFormPreviewShoulderHint:
       "Shoulders require at least {clearance} of clearance below the chin when detected.",
+    topMarginWarningHeading: "Requested top margin not supported",
+    topMarginWarningDescription:
+      "Requested top margin of {requested} could not be achieved.",
+    topMarginWarningAchieved: "The pipeline used {achieved} instead.",
+    topMarginWarningShoulder: "A larger top margin would crop the shoulders.",
+    topMarginWarningSource: "The source image lacks enough space above the crown.",
   },
   it: {
     appTitle: "Assistente foto digitale",
@@ -315,6 +321,12 @@ export const MESSAGES: Record<Language, Messages> = {
     closedFormPreviewTotalLabel: "Altezza totale",
     closedFormPreviewShoulderHint:
       "Le spalle richiedono almeno {clearance} di spazio sotto il mento quando rilevate.",
+    topMarginWarningHeading: "Margine superiore richiesto non supportato",
+    topMarginWarningDescription:
+      "Il margine superiore richiesto di {requested} non può essere rispettato.",
+    topMarginWarningAchieved: "Il sistema ha applicato invece {achieved}.",
+    topMarginWarningShoulder: "Un margine superiore maggiore taglierebbe le spalle.",
+    topMarginWarningSource: "L'immagine originale non ha spazio sufficiente sopra la testa.",
   },
   es: {
     appTitle: "Asistente de fotos digital",
@@ -472,5 +484,11 @@ export const MESSAGES: Record<Language, Messages> = {
     closedFormPreviewTotalLabel: "Altura total",
     closedFormPreviewShoulderHint:
       "Los hombros necesitan al menos {clearance} de espacio bajo el mentón cuando se detectan.",
+    topMarginWarningHeading: "Margen superior solicitado no disponible",
+    topMarginWarningDescription:
+      "No es posible usar el margen superior solicitado de {requested}.",
+    topMarginWarningAchieved: "El sistema utilizó {achieved} en su lugar.",
+    topMarginWarningShoulder: "Un margen superior mayor cortaría los hombros.",
+    topMarginWarningSource: "La imagen original no tiene espacio suficiente sobre la coronilla.",
   },
 };

--- a/client/app/routes/home/types.ts
+++ b/client/app/routes/home/types.ts
@@ -63,6 +63,7 @@ export type FaceResult = {
   markers: FaceMarker[];
   spans: FaceSpan[];
   pxPerMm: number | null;
+  topMarginWarning: TopMarginWarning | null;
 };
 
 export type Toast = {
@@ -192,6 +193,11 @@ export type Messages = {
   closedFormPreviewBottomLabel: string;
   closedFormPreviewTotalLabel: string;
   closedFormPreviewShoulderHint: string;
+  topMarginWarningHeading: string;
+  topMarginWarningDescription: string;
+  topMarginWarningAchieved: string;
+  topMarginWarningShoulder: string;
+  topMarginWarningSource: string;
 };
 
 export type FormValuesState = {
@@ -209,7 +215,6 @@ export type FormValuesState = {
   max_extra_padding_px: number;
   resize_scaling: number;
   min_top_mm: number;
-  min_bottom_mm: number;
   shoulder_clearance_mm: number;
 };
 
@@ -269,6 +274,15 @@ export type ResultsSectionProps = {
   onDownloadAsset: (asset: ImageAsset | null) => void;
   zipBlob: Blob | null;
   badgeStyles: BadgeStyles;
+};
+
+export type TopMarginWarning = {
+  requested: number | null;
+  achieved: number | null;
+  maxSupported: number | null;
+  sourceSupported: number | null;
+  exceedsShoulders: boolean;
+  exceedsSource: boolean;
 };
 
 export type AnnotatedPreviewProps = {

--- a/server.py
+++ b/server.py
@@ -238,27 +238,41 @@ def _process_request(
     target_crown_to_chin_mm: float,
     max_extra_padding_px: int,
     min_top_mm: float,
-    min_bottom_mm: float,
+    min_bottom_mm: Optional[float],
     shoulder_clearance_mm: float,
 ) -> StreamingResponse:
     normalized_mode = _normalise_pipeline_name(pipeline_mode)
     scaling = _clamp_resize_scaling(resize_scaling)
+    target_w_over_h_f = float(target_w_over_h)
+    top_margin_ratio_f = float(top_margin_ratio)
+    bottom_upper_ratio_f = float(bottom_upper_ratio)
+    target_height_mm_f = float(target_height_mm)
+    min_height_px_i = int(min_height_px)
+    min_width_px_i = int(min_width_px)
+    max_crown_to_chin_mm_f = float(max_crown_to_chin_mm)
+    min_crown_to_chin_mm_f = float(min_crown_to_chin_mm)
+    target_crown_to_chin_mm_f = float(target_crown_to_chin_mm)
+    max_extra_padding_px_i = int(max_extra_padding_px)
+    min_top_mm_f = float(min_top_mm)
+    shoulder_clearance_mm_f = float(shoulder_clearance_mm)
+    derived_min_bottom_mm = max(0.0, target_height_mm_f - min_top_mm_f - target_crown_to_chin_mm_f)
+
     params = RunParameters(
-        target_w_over_h=float(target_w_over_h),
-        top_margin_ratio=float(top_margin_ratio),
-        bottom_upper_ratio=float(bottom_upper_ratio),
-        target_height_mm=float(target_height_mm),
-        min_height_px=int(min_height_px),
-        min_width_px=int(min_width_px),
+        target_w_over_h=target_w_over_h_f,
+        top_margin_ratio=top_margin_ratio_f,
+        bottom_upper_ratio=bottom_upper_ratio_f,
+        target_height_mm=target_height_mm_f,
+        min_height_px=min_height_px_i,
+        min_width_px=min_width_px_i,
         resize_scaling=scaling,
-        max_crown_to_chin_mm=float(max_crown_to_chin_mm),
-        min_crown_to_chin_mm=float(min_crown_to_chin_mm),
-        target_crown_to_chin_mm=float(target_crown_to_chin_mm),
-        max_extra_padding_px=int(max_extra_padding_px),
+        max_crown_to_chin_mm=max_crown_to_chin_mm_f,
+        min_crown_to_chin_mm=min_crown_to_chin_mm_f,
+        target_crown_to_chin_mm=target_crown_to_chin_mm_f,
+        max_extra_padding_px=max_extra_padding_px_i,
         lock_ratio_after_resize=True,
-        min_top_mm=float(min_top_mm),
-        min_bottom_mm=float(min_bottom_mm),
-        shoulder_clearance_mm=float(shoulder_clearance_mm),
+        min_top_mm=min_top_mm_f,
+        min_bottom_mm=derived_min_bottom_mm,
+        shoulder_clearance_mm=shoulder_clearance_mm_f,
         use_closed_form=normalized_mode != "legacy",
     )
 
@@ -351,7 +365,7 @@ async def process_image(
         target_crown_to_chin_mm=target_crown_to_chin_mm,
         max_extra_padding_px=max_extra_padding_px,
         min_top_mm=defaults.min_top_mm,
-        min_bottom_mm=defaults.min_bottom_mm,
+        min_bottom_mm=None,
         shoulder_clearance_mm=defaults.shoulder_clearance_mm,
     )
 
@@ -378,7 +392,7 @@ async def process_image_v2(
     target_crown_to_chin_mm: float = Form(34.0),
     max_extra_padding_px: int = Form(600),
     min_top_mm: float = Form(4.0),
-    min_bottom_mm: float = Form(8.0),
+    min_bottom_mm: Optional[float] = Form(None),
     shoulder_clearance_mm: float = Form(3.0),
 ) -> StreamingResponse:
     """Run the configurable portrait-framing pipeline with closed-form support."""


### PR DESCRIPTION
## Summary
- derive the minimum bottom margin from the requested top margin and crown-to-chin target in the closed-form pipeline and expose top-margin limit flags in the face metadata
- have the API compute the derived bottom margin and forward the new warning flags to clients
- simplify the closed-form UI by removing the bottom-margin input, deriving it for previews and submissions, and surface localized warnings when the requested top margin is not achievable

## Testing
- python -m compileall portrait_framer.py server.py
- npm run typecheck *(fails: react-router CLI not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de729b6f54832db2e9b20b26e3800f