### PR TITLE
Fix closed-form preview geometry

### DIFF
--- a/client/app/routes/home/components/MmBudgetPreview.tsx
+++ b/client/app/routes/home/components/MmBudgetPreview.tsx
@@ -152,16 +152,13 @@ function computeBudgetGeometry({
   targetCrownToChinMm,
 }: MmBudgetPreviewProps): MmBudgetGeometry {
   const safeTargetHeight = Math.max(targetHeightMm, 1);
-  const minTop = Math.max(0, minTopMm);
+  const requestedTop = Math.max(0, minTopMm);
   const crownMin = Math.max(1, minCrownToChinMm);
   const crownMax = Math.max(crownMin, maxCrownToChinMm);
 
-  let faceMm = clamp(targetCrownToChinMm, crownMin, crownMax);
-  const maxFaceBudget = Math.max(crownMin, safeTargetHeight - minTop);
-  faceMm = clamp(faceMm, crownMin, maxFaceBudget);
-
-  const topMm = Math.min(Math.max(minTop, safeTargetHeight - faceMm), safeTargetHeight);
-  const bottomMm = Math.max(0, safeTargetHeight - faceMm - topMm);
+  const faceMm = clamp(targetCrownToChinMm, crownMin, crownMax);
+  const topMm = Math.min(requestedTop, safeTargetHeight);
+  const bottomMm = Math.max(0, safeTargetHeight - topMm - faceMm);
 
   const totalMm = topMm + faceMm + bottomMm;
   const normaliser = totalMm > 0 ? totalMm : 1;
@@ -174,9 +171,9 @@ function computeBudgetGeometry({
     topPercent: (topMm / normaliser) * 100,
     facePercent: (faceMm / normaliser) * 100,
     bottomPercent: (bottomMm / normaliser) * 100,
-    topLimited: topMm <= minTop + 0.05,
+    topLimited: topMm + 0.05 < requestedTop,
     bottomLimited: bottomMm <= 0.05,
-    faceLimited: Math.abs(faceMm - crownMin) <= 0.05 || Math.abs(faceMm - maxFaceBudget) <= 0.05,
+    faceLimited: Math.abs(faceMm - crownMin) <= 0.05 || Math.abs(faceMm - crownMax) <= 0.05,
   };
 }
 


### PR DESCRIPTION
## Summary
- align the closed-form mm budget preview with the requested top margin and crown-to-chin target values
- update the limit indicators to highlight when inputs exceed achievable bounds

## Testing
- npm run dev -- --host 0.0.0.0 --port 3000 (manually inspected preview)


------
https://chatgpt.com/codex/tasks/task_e_68deb9336ea8832da57a6f4ae4f1af68