### PR TITLE
Add glassmorphic styling to preserve quality slider

### DIFF
--- a/client/app/app.css
+++ b/client/app/app.css
@@ -13,3 +13,67 @@ body {
     color-scheme: dark;
   }
 }
+
+.funnel-slider {
+  @apply relative h-9 w-full rounded-full transition;
+}
+
+.funnel-slider:focus-within {
+  @apply ring-2 ring-sky-500 ring-offset-2 ring-offset-white dark:ring-offset-slate-900;
+}
+
+.funnel-track-base,
+.funnel-track-fill {
+  background: linear-gradient(90deg, #ef4444 0%, #f97316 30%, #facc15 65%, #22c55e 100%);
+  clip-path: polygon(0% 65%, 0% 35%, 100% 0%, 100% 100%);
+}
+
+.funnel-track-base {
+  @apply absolute inset-0 rounded-full opacity-30;
+  z-index: 0;
+}
+
+.funnel-track-fill {
+  @apply absolute inset-y-0 left-0 rounded-full;
+  z-index: 1;
+}
+
+.funnel-slider-thumb {
+  @apply pointer-events-none absolute top-1/2 h-8 w-8 -translate-y-1/2 rounded-full transition;
+  transform: translate(-50%, -50%);
+  z-index: 2;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.92), rgba(255, 255, 255, 0.12));
+  border: 1px solid rgba(255, 255, 255, 0.65);
+  box-shadow: 0 12px 24px -14px rgba(15, 23, 42, 0.55);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+}
+
+.funnel-slider-thumb::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: radial-gradient(
+      circle at 30% 30%,
+      rgba(255, 255, 255, 0.9),
+      rgba(255, 255, 255, 0) 60%
+    ),
+    linear-gradient(135deg, rgba(255, 255, 255, 0.35), rgba(255, 255, 255, 0));
+  mix-blend-mode: screen;
+  pointer-events: none;
+}
+
+.dark .funnel-slider-thumb {
+  border-color: rgba(15, 23, 42, 0.6);
+  box-shadow: 0 12px 24px -14px rgba(0, 0, 0, 0.7);
+}
+
+.funnel-slider-input {
+  @apply absolute inset-0 h-full w-full cursor-pointer appearance-none rounded-full bg-transparent focus-visible:outline-none;
+  z-index: 3;
+}
+
+.funnel-slider-input:disabled {
+  @apply cursor-not-allowed;
+}

--- a/client/app/routes/home/components/OptionsSection.tsx
+++ b/client/app/routes/home/components/OptionsSection.tsx
@@ -1,4 +1,4 @@
-import type { ChangeEvent } from "react";
+import type { ChangeEvent, CSSProperties } from "react";
 import { useMemo, useState } from "react";
 import classNames from "classnames";
 
@@ -381,6 +381,22 @@ type PercentageSliderProps = {
 
 function PercentageSlider({ label, value, onChange, minPercent, maxPercent, disabled }: PercentageSliderProps) {
   const sliderValue = clamp(Math.round(value * 100), minPercent, maxPercent);
+  const percentRange = Math.max(maxPercent - minPercent, 1);
+  const progress = ((sliderValue - minPercent) / percentRange) * 100;
+  const percent = clamp(Number.isFinite(progress) ? progress : 0, 0, 100);
+  const thumbHue = 120 * (percent / 100);
+  const thumbAccent = `hsla(${Math.round(thumbHue)}, 95%, 60%, 0.35)`;
+  const thumbHighlight = `hsla(${Math.round(thumbHue)}, 90%, 55%, 0.6)`;
+  const thumbStyle = useMemo(
+    () =>
+      ({
+        left: `${percent}%`,
+        backgroundImage: `linear-gradient(135deg, rgba(255,255,255,0.95), rgba(255,255,255,0.08)), radial-gradient(circle at 28% 28%, rgba(255,255,255,0.85), rgba(255,255,255,0) 60%), linear-gradient(90deg, ${thumbAccent}, ${thumbHighlight})`,
+        borderColor: thumbHighlight,
+        boxShadow: `0 12px 24px -14px rgba(15,23,42,0.65), 0 0 0 1px ${thumbHighlight}, 0 0 18px ${thumbAccent}`,
+      }) as CSSProperties,
+    [percent, thumbAccent, thumbHighlight],
+  );
 
   const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
     const nextPercent = Number.parseInt(event.target.value, 10);
@@ -397,16 +413,27 @@ function PercentageSlider({ label, value, onChange, minPercent, maxPercent, disa
         <span>{label}</span>
         <span className="text-xs font-semibold text-slate-500 dark:text-slate-400">{sliderValue}%</span>
       </span>
-      <input
-        type="range"
-        min={minPercent}
-        max={maxPercent}
-        value={sliderValue}
-        step={1}
-        disabled={disabled}
-        onChange={handleChange}
-        className="h-2 w-full cursor-pointer appearance-none rounded-full bg-slate-200 accent-sky-500 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 dark:bg-slate-700"
-      />
+      <div
+        className={classNames(
+          "funnel-slider",
+          disabled && "pointer-events-none opacity-60",
+        )}
+      >
+        <div className="funnel-track-base" aria-hidden="true" />
+        <div className="funnel-track-fill" aria-hidden="true" style={{ width: `${percent}%` }} />
+        <div className="funnel-slider-thumb" aria-hidden="true" style={thumbStyle} />
+        <input
+          type="range"
+          min={minPercent}
+          max={maxPercent}
+          value={sliderValue}
+          step={1}
+          disabled={disabled}
+          onChange={handleChange}
+          className="funnel-slider-input"
+          aria-label={label}
+        />
+      </div>
     </label>
   );
 }


### PR DESCRIPTION
## Summary
- enlarge the Preserve quality slider thumb and layer in glassmorphic gradients, blur, and highlights
- tint the thumb border, glow, and background blend to follow the funnel track's red-to-green accent as values increase

## Testing
- npm run typecheck *(fails: react-router command not found in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68decf281e38832db27179269abc77c5